### PR TITLE
use GITHUB_TOKEN environment variable to send authenticated requests to api

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { cacheFile, downloadTool, find } from '@actions/tool-cache'
 import { chmodSync } from 'fs'
 import { exec } from '@actions/exec'
 import { HttpClient } from '@actions/http-client'
+import { BearerCredentialHandler } from '@actions/http-client/auth'
 
 const COPILOT_CLI_TOOL_NAME = 'aws-copilot-cli'
 
@@ -65,7 +66,19 @@ async function install(): Promise<void> {
 }
 
 async function getLatestVersion(): Promise<string> {
-  const http = new HttpClient('aws-copilot-release')
+  const token = process.env['GITHUB_TOKEN']
+  const handlers = []
+
+  if (token) {
+    core.info('Using GITHUB_TOKEN to get latest version')
+    handlers.push(new BearerCredentialHandler(token))
+  }
+
+  const http = new HttpClient('aws-copilot-release', handlers, {
+    allowRetries: true,
+    maxRetries: 3
+  })
+
   const response = await http.getJson(
     'https://api.github.com/repos/aws/copilot-cli/releases/latest'
   )


### PR DESCRIPTION
Hi, this PR is for fixing the GitHub API rate limit error that happens when trying to read the latest version.
I wanted to confirm if this works by releasing a forked version to the GitHub marketplace but it is taking a very long time to get approved.

I was able to confirm that the code works by running this snippet on my local computer, but I am not sure if it will work inside CI because I don't know if the `GITHUB_TOKEN` environment variable will be accessible. (It should be but you never know..)

copy and paste the code inside the following file: `src/main.js`
then get an access token from GitHub: https://github.com/settings/tokens
then run the script like this:
```bash
$ GITHUB_TOKEN=bad-token node ./src/main.js
$ GITHUB_TOKEN=ghp_KqOF63MO2DXIVSUK42uZapxhs4km393WxXyX node ./src/main.js
```

And you should be able to see that the request goes through correctly when the token is valid.

```
// src/main.js

const HttpClient = require('@actions/http-client').HttpClient 
const BearerCredentialHandler = require('@actions/http-client/auth').BearerCredentialHandler

async function getLatestVersion() {
  const token = process.env['GITHUB_TOKEN']
  const handlers = []

  if (token) {
    console.log('Using GITHUB_TOKEN to get latest version')
    handlers.push(new BearerCredentialHandler(token))
  }

  const http = new HttpClient('aws-copilot-release', handlers, {
    allowRetries: true,
    maxRetries: 3
  })

  const response = await http.getJson(
    'https://api.github.com/repos/aws/copilot-cli/releases/latest'
  )
  const latestVersion = response.result.tag_name
  return latestVersion
}

getLatestVersion()
.then(version => {
  console.log('latest_version', version)
})
.catch((err) => {
  console.log(err.message)
})
``` 