### PR TITLE
enable usage of --force flag

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -124,7 +124,7 @@ async function deployApp(): Promise<void> {
   const env = core.getInput('env')
   const path = core.getInput('path') || '.'
 
-  const force = false;
+  const force = core.getInput('force') === 'true'
 
   if (!app) {
     throw new Error('App name is required')


### PR DESCRIPTION
Hi there,

We had a few builds fail at the very last moment with an error message stating something like:
>  aws-copilot aborted the release because nothing changed

(Sorry, I can't find the failing build at this moment)

But I believe that the "--force" flag will fix our problem.
It looks like the logic was already implemented, but disabled.

I made a PR to re-enable it, please let me know if this is OK.

Thank you. 